### PR TITLE
Add custom fieldPrefix and contentField in JsonXMLConfig

### DIFF
--- a/core/src/main/java/de/odysseus/staxon/json/JsonXMLConfig.java
+++ b/core/src/main/java/de/odysseus/staxon/json/JsonXMLConfig.java
@@ -80,6 +80,14 @@ public interface JsonXMLConfig {
 		public Map<String,String> getNamespaceMappings() {
 			return null;
 		}
+      @Override
+      public String getFieldPrefix() {
+         return "@";
+      }
+      @Override
+      public String getContentField() {
+         return "$";
+      }
 	};
 	
 	/**
@@ -161,4 +169,8 @@ public interface JsonXMLConfig {
 	 * @return prefix/URI mappings
 	 */
 	public Map<String, String> getNamespaceMappings();
+
+   public String getFieldPrefix();
+
+   public String getContentField();
 }

--- a/core/src/main/java/de/odysseus/staxon/json/JsonXMLConfigBuilder.java
+++ b/core/src/main/java/de/odysseus/staxon/json/JsonXMLConfigBuilder.java
@@ -164,4 +164,16 @@ public class JsonXMLConfigBuilder {
 		config.setNamespaceMappings(namespaceMappings);
 		return this;
 	}
+	
+	public JsonXMLConfigBuilder fieldPrefix(String fieldPrefix)
+	{
+	   config.setFieldPrefix(fieldPrefix);
+	   return this;
+	}
+	
+	public JsonXMLConfigBuilder contentField(String contentField)
+	{
+	   config.setContentField(contentField);
+	   return this;
+	}
 }

--- a/core/src/main/java/de/odysseus/staxon/json/JsonXMLConfigImpl.java
+++ b/core/src/main/java/de/odysseus/staxon/json/JsonXMLConfigImpl.java
@@ -37,6 +37,9 @@ public class JsonXMLConfigImpl implements JsonXMLConfig, Cloneable {
 	
 	private boolean repairingNamespaces = JsonXMLConfig.DEFAULT.isRepairingNamespaces();
 	
+	private String fieldPrefix = JsonXMLConfig.DEFAULT.getFieldPrefix();
+	private String contentField = JsonXMLConfig.DEFAULT.getContentField();
+	
 	@Override
 	protected JsonXMLConfigImpl clone() {
 		try {
@@ -126,4 +129,28 @@ public class JsonXMLConfigImpl implements JsonXMLConfig, Cloneable {
 	public void setNamespaceMappings(Map<String, String> namespaceMappings) {
 		this.namespaceMappings = namespaceMappings;
 	}
+
+   @Override
+   public String getFieldPrefix() {
+      return fieldPrefix;
+   }
+   
+   public void setFieldPrefix(String fieldPrefix) {
+      if(fieldPrefix == null) {
+         return; // keep default value
+      }
+      this.fieldPrefix = fieldPrefix;
+   }
+
+   @Override
+   public String getContentField() {
+      return contentField;
+   }
+   
+   public void setContentField(String contentField) {
+      if(contentField == null) {
+         return; // keep default value
+      }
+      this.contentField = contentField;
+   }
 }

--- a/core/src/main/java/de/odysseus/staxon/json/JsonXMLOutputFactory.java
+++ b/core/src/main/java/de/odysseus/staxon/json/JsonXMLOutputFactory.java
@@ -109,6 +109,9 @@ public class JsonXMLOutputFactory extends AbstractXMLOutputFactory {
 	 * <p>The default value is <code>false</code>.</p>
 	 */
 	public static final String PROP_PRETTY_PRINT = "JsonXMLOutputFactory.prettyPrint";
+	
+	public static final String PROP_FIELD_PREFIX = "JsonXMLOutputFactory.fieldPrefix";
+	public static final String PROP_CONTENT_FIELD = "JsonXMLOutputFactory.contentField";
 
 	private JsonStreamFactory streamFactory;
 	private boolean multiplePI;
@@ -119,6 +122,9 @@ public class JsonXMLOutputFactory extends AbstractXMLOutputFactory {
 	private char namespaceSeparator;
 	private boolean namespaceDeclarations;
 	private Map<String, String> namespaceMappings;
+	
+	private String fieldPrefix;
+   private String contentField;
 
 	public JsonXMLOutputFactory() throws FactoryConfigurationError {
 		this(JsonXMLConfig.DEFAULT);
@@ -143,6 +149,9 @@ public class JsonXMLOutputFactory extends AbstractXMLOutputFactory {
 		this.namespaceMappings = config.getNamespaceMappings();
 		this.streamFactory = streamFactory;
 
+		this.fieldPrefix = config.getFieldPrefix();
+		this.contentField = config.getContentField();
+		
 		/*
 		 * initialize standard properties
 		 */
@@ -189,7 +198,9 @@ public class JsonXMLOutputFactory extends AbstractXMLOutputFactory {
 	@Override
 	public JsonXMLStreamWriter createXMLStreamWriter(Writer stream) throws XMLStreamException {
 		try {
-			return new JsonXMLStreamWriter(decorate(streamFactory.createJsonStreamTarget(stream, prettyPrint)), repairNamespacesMap(), multiplePI, namespaceSeparator, namespaceDeclarations);
+			return new JsonXMLStreamWriter(decorate(streamFactory.createJsonStreamTarget(stream, prettyPrint)),
+			      repairNamespacesMap(), multiplePI, namespaceSeparator, namespaceDeclarations,
+			      fieldPrefix, contentField);
 		} catch (IOException e) {
 			throw new XMLStreamException(e);
 		}
@@ -198,7 +209,9 @@ public class JsonXMLOutputFactory extends AbstractXMLOutputFactory {
 	@Override
 	public JsonXMLStreamWriter createXMLStreamWriter(OutputStream stream) throws XMLStreamException {
 		try {
-			return new JsonXMLStreamWriter(decorate(streamFactory.createJsonStreamTarget(stream, prettyPrint)), repairNamespacesMap(), multiplePI, namespaceSeparator, namespaceDeclarations);
+			return new JsonXMLStreamWriter(decorate(streamFactory.createJsonStreamTarget(stream, prettyPrint)),
+			      repairNamespacesMap(), multiplePI, namespaceSeparator, namespaceDeclarations,
+			      fieldPrefix, contentField);
 		} catch (IOException e) {
 			throw new XMLStreamException(e);
 		}
@@ -212,7 +225,9 @@ public class JsonXMLOutputFactory extends AbstractXMLOutputFactory {
 	@Override
 	public boolean isPropertySupported(String name) {
 		return super.isPropertySupported(name)
-			|| Arrays.asList(PROP_AUTO_ARRAY, PROP_MULTIPLE_PI, PROP_VIRTUAL_ROOT, PROP_NAMESPACE_SEPARATOR, PROP_NAMESPACE_DECLARATIONS, PROP_NAMESPACE_MAPPINGS, PROP_PRETTY_PRINT).contains(name);
+			|| Arrays.asList(PROP_AUTO_ARRAY, PROP_MULTIPLE_PI, PROP_VIRTUAL_ROOT, PROP_NAMESPACE_SEPARATOR,
+			      PROP_NAMESPACE_DECLARATIONS, PROP_NAMESPACE_MAPPINGS, PROP_PRETTY_PRINT,
+			      PROP_FIELD_PREFIX, PROP_CONTENT_FIELD).contains(name);
 	}
 
 	@Override
@@ -236,6 +251,10 @@ public class JsonXMLOutputFactory extends AbstractXMLOutputFactory {
 				return Boolean.valueOf(namespaceDeclarations);
 			} else if (PROP_NAMESPACE_MAPPINGS.equals(name)) {
 				return namespaceMappings;
+			} else if(PROP_FIELD_PREFIX.equals(name)) {
+			   return fieldPrefix;
+			} else if (PROP_CONTENT_FIELD.equals(name)) {
+			   return contentField;
 			} else {
 				throw new IllegalArgumentException("Unsupported property: " + name);
 			}
@@ -265,7 +284,11 @@ public class JsonXMLOutputFactory extends AbstractXMLOutputFactory {
 				@SuppressWarnings("unchecked")
 				Map<String, String> map = (Map<String, String>)value;
 				this.namespaceMappings = map;
-			} else {
+			} else if(PROP_FIELD_PREFIX.equals(name)) {
+            fieldPrefix = (String) value;
+         } else if (PROP_CONTENT_FIELD.equals(name)) {
+            contentField = (String) value;
+         } else {
 				throw new IllegalArgumentException("Unsupported property: " + name);
 			}
 		}

--- a/core/src/main/java/de/odysseus/staxon/json/JsonXMLStreamWriter.java
+++ b/core/src/main/java/de/odysseus/staxon/json/JsonXMLStreamWriter.java
@@ -105,6 +105,9 @@ public class JsonXMLStreamWriter extends AbstractXMLStreamWriter<JsonXMLStreamWr
 	private final boolean skipSpace;
 	private final char namespaceSeparator;
 	private final boolean namespaceDeclarations;
+	
+	private final String fieldPrefix;
+	private final String contentField;
 
 	private boolean documentArray = false;
 
@@ -116,7 +119,8 @@ public class JsonXMLStreamWriter extends AbstractXMLStreamWriter<JsonXMLStreamWr
 	 * @param namespaceSeparator namespace prefix separator
 	 * @param namespaceDeclarations whether to write namespace declarations
 	 */
-	public JsonXMLStreamWriter(JsonStreamTarget target, boolean repairNamespaces, boolean multiplePI, char namespaceSeparator, boolean namespaceDeclarations) {
+	public JsonXMLStreamWriter(JsonStreamTarget target, boolean repairNamespaces, boolean multiplePI,
+	      char namespaceSeparator, boolean namespaceDeclarations, String fieldPrefix, String contentField) {
 		super(new ScopeInfo(), repairNamespaces);
 		this.target = target;
 		this.multiplePI = multiplePI;
@@ -124,6 +128,9 @@ public class JsonXMLStreamWriter extends AbstractXMLStreamWriter<JsonXMLStreamWr
 		this.namespaceDeclarations = namespaceDeclarations;
 		this.autoEndArray = true;
 		this.skipSpace = true;
+		
+		this.fieldPrefix = fieldPrefix;
+		this.contentField = contentField;
 	}
 
 	/**
@@ -134,7 +141,8 @@ public class JsonXMLStreamWriter extends AbstractXMLStreamWriter<JsonXMLStreamWr
 	 * @param namespaceSeparator namespace prefix separator
 	 * @param namespaceDeclarations whether to write namespace declarations
 	 */
-	public JsonXMLStreamWriter(JsonStreamTarget target, Map<String, String> repairNamespaces, boolean multiplePI, char namespaceSeparator, boolean namespaceDeclarations) {
+	public JsonXMLStreamWriter(JsonStreamTarget target, Map<String, String> repairNamespaces, boolean multiplePI,
+	      char namespaceSeparator, boolean namespaceDeclarations, String fieldPrefix, String contentField) {
 		super(new ScopeInfo(), repairNamespaces);
 		this.target = target;
 		this.multiplePI = multiplePI;
@@ -142,6 +150,9 @@ public class JsonXMLStreamWriter extends AbstractXMLStreamWriter<JsonXMLStreamWr
 		this.namespaceDeclarations = namespaceDeclarations;
 		this.autoEndArray = true;
 		this.skipSpace = true;
+		
+		this.fieldPrefix = fieldPrefix;
+      this.contentField = contentField;
 	}
 
 	private String getFieldName(String prefix, String localName) {
@@ -198,7 +209,7 @@ public class JsonXMLStreamWriter extends AbstractXMLStreamWriter<JsonXMLStreamWr
 		try {
 			if (getScope().getInfo().hasData()) {
 				if (getScope().getInfo().startObjectWritten) {
-					target.name("$");
+					target.name(contentField);
 				}
 				target.value(getScope().getInfo().getData());
 			}
@@ -223,7 +234,7 @@ public class JsonXMLStreamWriter extends AbstractXMLStreamWriter<JsonXMLStreamWr
 				target.startObject();
 				getScope().getInfo().startObjectWritten = true;
 			}
-			target.name('@' + name);
+			target.name(fieldPrefix + name);
 			target.value(value);
 		} catch (IOException e) {
 			throw new XMLStreamException("Cannot write attribute: " + name, e);
@@ -239,9 +250,9 @@ public class JsonXMLStreamWriter extends AbstractXMLStreamWriter<JsonXMLStreamWr
 					getScope().getInfo().startObjectWritten = true;
 				}
 				if (XMLConstants.DEFAULT_NS_PREFIX.equals(prefix)) {
-					target.name('@' + XMLConstants.XMLNS_ATTRIBUTE);
+					target.name(fieldPrefix + XMLConstants.XMLNS_ATTRIBUTE);
 				} else {
-					target.name('@' + XMLConstants.XMLNS_ATTRIBUTE + namespaceSeparator + prefix);
+					target.name(fieldPrefix + XMLConstants.XMLNS_ATTRIBUTE + namespaceSeparator + prefix);
 				}
 				target.value(namespaceURI);
 			} catch (IOException e) {

--- a/core/src/main/java/de/odysseus/staxon/json/jaxb/JsonXML.java
+++ b/core/src/main/java/de/odysseus/staxon/json/jaxb/JsonXML.java
@@ -125,4 +125,7 @@ public @interface JsonXML {
 	 * namespaces.</p>
 	 */
 	String[] namespaceMappings() default {};
+	
+	String fieldPrefix() default "@";
+	String contentField() default "$";
 }

--- a/core/src/test/java/de/odysseus/staxon/json/stream/util/AutoArrayTargetTest.java
+++ b/core/src/test/java/de/odysseus/staxon/json/stream/util/AutoArrayTargetTest.java
@@ -32,7 +32,7 @@ public class AutoArrayTargetTest {
 	}
 	
 	private JsonXMLStreamWriter createXmlStreamWriter(StringWriter result) throws IOException {
-		return new JsonXMLStreamWriter(createTarget(result), false, true, ':', true);
+		return new JsonXMLStreamWriter(createTarget(result), false, true, ':', true, "@", "$");
 	}
 	
 	/**

--- a/core/src/test/java/de/odysseus/staxon/json/stream/util/AutoPrimitiveTargetTest.java
+++ b/core/src/test/java/de/odysseus/staxon/json/stream/util/AutoPrimitiveTargetTest.java
@@ -33,7 +33,7 @@ public class AutoPrimitiveTargetTest {
 	}
 	
 	private JsonXMLStreamWriter createXmlStreamWriter(StringWriter result) throws IOException {
-		return new JsonXMLStreamWriter(createTarget(result), false, true, ':', true);
+		return new JsonXMLStreamWriter(createTarget(result), false, true, ':', true, "@", "$");
 	}
 	
 	/**

--- a/core/src/test/java/de/odysseus/staxon/json/stream/util/RemoveRootTargetTest.java
+++ b/core/src/test/java/de/odysseus/staxon/json/stream/util/RemoveRootTargetTest.java
@@ -34,7 +34,7 @@ public class RemoveRootTargetTest {
 	}
 
 	private JsonXMLStreamWriter createXmlStreamWriter(StringWriter result, QName root) throws IOException {
-		return new JsonXMLStreamWriter(createTarget(result, root), false, true, ':', true);
+		return new JsonXMLStreamWriter(createTarget(result, root), false, true, ':', true, "@", "$");
 	}
 
 	/**


### PR DESCRIPTION
Allows to configure how Staxon converts XML attributes and plain text to Json fields.
The default behaviour ("@" for attributes, "$" for plain text) remains unchanged.